### PR TITLE
Use arrays instead of dicts. Fixes build on OpenBSD.

### DIFF
--- a/gambatte_sdl/SConstruct
+++ b/gambatte_sdl/SConstruct
@@ -9,7 +9,7 @@ vars.Add('CXX')
 env = Environment(CPPPATH = ['src', '../libgambatte/include', '../common'],
                   CFLAGS = cflags,
                   CXXFLAGS = cxxflags,
-                  CPPDEFINES = { 'HAVE_STDINT_H': None },
+                  CPPDEFINES = [ 'HAVE_STDINT_H', None ],
                   variables = vars)
 env.ParseConfig('sdl-config --cflags --libs')
 
@@ -44,11 +44,11 @@ conf = env.Configure()
 conf.CheckLib('z')
 conf.Finish()
 
-version_str_def = {}
+version_str_def = []
 if Dir('../.git').exists():
 	try:
 		git_revno = subprocess.check_output("git rev-list HEAD --count", shell=True).strip()
-		version_str_def = { 'GAMBATTE_SDL_VERSION_STR': r'\"r' + git_revno + r'\"' }
+		version_str_def = [ 'GAMBATTE_SDL_VERSION_STR', r'\"r' + git_revno + r'\"' ]
 	except subprocess.CalledProcessError:
 		pass
 


### PR DESCRIPTION
Currently the build fails on OpenBSD with:

g++ -o src/gambatte_sdl.o -c -Wall -Wextra -O2 -fomit-frame-pointer -fno-excepti
ons -fno-rtti -pthread -R/usr/X11R6/lib "-D{'HAVE_STDINT_H': None}" -D_GNU_SOURC
E=1 -D_REENTRANT -DXTHREADS "-D{'GAMBATTE_SDL_VERSION_STR': '\"r532\"'}" -Isrc
 -I/tmp/gambatte/libgambatte/include -I/tmp/gambatte/common -I/usr/local/include
 -I/usr/local/include/SDL -I/usr/X11R6/include src/gambatte_sdl.cpp
<command-line>: error: macro names must be identifiers
<command-line>: error: macro names must be identifiers
<command-line>: warning: missing terminating ' character
scons: **\* [src/gambatte_sdl.o] Error 1

Using arrays instead of dicts lets gambatte_sdl build.
