### PR TITLE
Don't invoke undefined behavior by memcpy()ing backwards.

### DIFF
--- a/gambatte_qt/src/framework/src/SDL_Joystick/src/SDL_joystick.c
+++ b/gambatte_qt/src/framework/src/SDL_Joystick/src/SDL_joystick.c
@@ -376,7 +376,7 @@ void SDL_JoystickClose(SDL_Joystick *joystick)
 	/* Remove joystick from list */
 	for ( i=0; SDL_joysticks[i]; ++i ) {
 		if ( joystick == SDL_joysticks[i] ) {
-			SDL_memcpy(&SDL_joysticks[i], &SDL_joysticks[i+1],
+			SDL_memmove(&SDL_joysticks[i], &SDL_joysticks[i+1],
 			       (SDL_numjoysticks-i)*sizeof(joystick));
 			break;
 		}


### PR DESCRIPTION
memcpy()’s behavior when copying two overlapping buffers is undefined. memmove()’s behavior in the same situation is defined: the copy succeeds with no corruption. Other than that, the functions are identical.

This fixes a crash on OpenBSD, which aborts on overlapping memcpy.