### PR TITLE
gambatte_sdl: fix joystick input parsing for multi-digit numbers.

### DIFF
--- a/gambatte_sdl/src/gambatte_sdl.cpp
+++ b/gambatte_sdl/src/gambatte_sdl.cpp
@@ -340,7 +340,7 @@ void InputOption::exec(char const *const *argv, int index) {
 			if (num < 0 || num > 255)
 				continue;
 
-			s += (dev_num > 9) + (dev_num > 99);
+			s += (num > 9) + (num > 99);
 
 			InputId id;
 			id.jdata.dev_num = dev_num;


### PR DESCRIPTION
Fixes bug preventing joystick input from being accepted by the parser when `dev_num` and `num` have different numbers of digits.