### PR TITLE
Changes for windows compilation (SDL-Only)

### DIFF
--- a/gambatte_sdl/SConstruct
+++ b/gambatte_sdl/SConstruct
@@ -1,17 +1,18 @@
 import subprocess
 
-cflags   = ARGUMENTS.get('CFLAGS', '-Wall -Wextra -O2 -fomit-frame-pointer')
+cflags   = ARGUMENTS.get('CFLAGS', '-DHAVE_STDINT_H -Wall -Wextra -O2 -fomit-frame-pointer')
 cxxflags = ARGUMENTS.get('CXXFLAGS', cflags + ' -fno-exceptions -fno-rtti')
 vars = Variables()
 vars.Add('CC')
 vars.Add('CXX')
 
-env = Environment(CPPPATH = ['src', '../libgambatte/include', '../common'],
-                  CFLAGS = cflags,
-                  CXXFLAGS = cxxflags,
-                  CPPDEFINES = [ 'HAVE_STDINT_H', None ],
-                  variables = vars)
-env.ParseConfig('sdl-config --cflags --libs')
+env = Environment(
+    CPPPATH = ['src', '../libgambatte/include', '../common'],
+    CFLAGS = cflags,
+    CXXFLAGS = cxxflags,
+    variables = vars
+)
+
 
 sourceFiles = Split('''
 			src/audiosink.cpp
@@ -40,6 +41,20 @@ sourceFiles = Split('''
 			../libgambatte/libgambatte.a
 		   ''')
 
+if env['PLATFORM'] == "win32":
+    env['LIBS'] = [
+        r"C:\Program Files (x86)\SDL-1.2.15\lib\x64\SDLmain.lib",
+        r"C:\Program Files (x86)\SDL-1.2.15\lib\x64\SDL.lib",
+    ]
+    env['CPPPATH'].append("C:\Program Files (x86)\SDL-1.2.15\include")
+    env['LINKFLAGS'] = ['-SUBSYSTEM:CONSOLE']
+
+    env['CFLAGS'] = "".join(env['CFLAGS'].split('-Wextra'))
+    env['CXXFLAGS'] = "".join(env['CXXFLAGS'].split('-Wextra'))
+    sourceFiles[-1] = '../libgambatte/gambatte.lib'
+else:
+    env.ParseConfig('sdl-config --cflags --libs')
+
 conf = env.Configure()
 conf.CheckLib('z')
 conf.Finish()
@@ -54,5 +69,5 @@ if Dir('../.git').exists():
 
 env.Program('gambatte_sdl',
             [env.Object('src/gambatte_sdl.cpp',
-                        CPPDEFINES = env['CPPDEFINES'] + [version_str_def])]
+                        CPPDEFINES = [version_str_def])]
             + sourceFiles)

--- a/gambatte_sdl/src/gambatte_sdl.cpp
+++ b/gambatte_sdl/src/gambatte_sdl.cpp
@@ -28,6 +28,7 @@
 #include <gambatte.h>
 #include <pakinfo.h>
 #include <SDL.h>
+#undef main
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>

--- a/libgambatte/SConstruct
+++ b/libgambatte/SConstruct
@@ -1,6 +1,6 @@
 global_cflags = ARGUMENTS.get('CFLAGS', '-Wall -Wextra -O2 -fomit-frame-pointer')
 global_cxxflags = ARGUMENTS.get('CXXFLAGS', global_cflags + ' -fno-exceptions -fno-rtti')
-global_defines = ' -DHAVE_STDINT_H'
+global_defines = ' -DHAVE_STDINT_H -DNOMINMAX'
 vars = Variables()
 vars.Add('CC')
 vars.Add('CXX')
@@ -9,6 +9,10 @@ env = Environment(CPPPATH = ['src', 'include', '../common'],
                   CFLAGS = global_cflags + global_defines,
                   CXXFLAGS = global_cxxflags + global_defines,
                   variables = vars)
+
+if env['PLATFORM'] == "win32":
+    env['CFLAGS'] = "".join(env['CFLAGS'].split('-Wextra'))
+    env['CXXFLAGS'] = "".join(env['CXXFLAGS'].split('-Wextra'))
 
 sourceFiles = Split('''
 			src/bitmap_font.cpp

--- a/libgambatte/src/mem/cartridge.cpp
+++ b/libgambatte/src/mem/cartridge.cpp
@@ -22,6 +22,7 @@
 #include "pakinfo_internal.h"
 #include <cstring>
 #include <fstream>
+#include <algorithm>
 
 namespace gambatte {
 


### PR DESCRIPTION
Windows is a special monkey and needs some assistance in compilation. These changes are for the standard VC2015 compilation not through CYGWIN and MINGW which may not need these changes.

This fixes the build for SDL. The QT version might need more changes.

Other version information:

* Windows 10 SDK
* x64 Native Compilation (64-bit)
* VC2015
* SCONS v2.4.1
* SDL 1.2.15

Changes implementented:

* Define `-DNOMINMAX`
	* This solves issues with Windows.h clobbering the STD::MIN, STD::MAX macros with their own and causing many obscure syntax errors during compilation.
* Add `-SUBSYSTEM:CONSOLE` to linker options
	* Fixes error message: `LINK : fatal error LNK1561: entry point must be defined`
	* Source: http://stackoverflow.com/a/28256749
* Remove `env.ParseConfig('sdl-config')`
	* This utility script isn't available on windows.
	* Replace with the direct path to the libs and headers
	* SDL libs can be downloaded here: https://www.libsdl.org/download-1.2.php (SDL-devel-1.2.15-VC.zip (Visual C++) is needed)
	* Since Windows doesn't have a standard method for detecting header/lib paths, the paths were set manually to "C:\Program Files (x86)\SDL-1.2.15\include", etc.
* Remove '-Wextra' under windows
	* This isn't defined in the Windows compiler.
	* Note that '-Wall' compilation is very slow. Perhaps consider removing this under windows also.
* Add `#include <algorithm>` to `cartridge.cpp`
	* This adds a few macros needed to compile
* Move `-DHAVE_STDINT_H` to the global compiler flags. The previous way of doing this caused linker issues (specifically 3 functions wouldn't link correctly).
* Add `#undef main` in `gambatte_sdl.cpp`