### PR TITLE
Freeze the CPU on Invalid Opcodes

### DIFF
--- a/libgambatte/src/cpu.h
+++ b/libgambatte/src/cpu.h
@@ -79,6 +79,7 @@ private:
 	unsigned hf1, hf2, zf, cf;
 	unsigned char a_, b, c, d, e, /*f,*/ h, l;
 	bool skip_;
+	bool hang_;
 
 	void process(unsigned long cycles);
 };

--- a/libgambatte/src/initstate.cpp
+++ b/libgambatte/src/initstate.cpp
@@ -1179,6 +1179,7 @@ void gambatte::setInitState(SaveState &state, bool const cgb, bool const gbaCgbM
 	state.cpu.h = 0x01;
 	state.cpu.l = 0x4D;
 	state.cpu.skip = false;
+	state.cpu.hang = false;
 
 	std::memset(state.mem.sram.ptr, 0xFF, state.mem.sram.size());
 

--- a/libgambatte/src/savestate.h
+++ b/libgambatte/src/savestate.h
@@ -55,6 +55,7 @@ struct SaveState {
 		unsigned char h;
 		unsigned char l;
 		unsigned char /*bool*/ skip;
+		unsigned char /*bool*/ hang;
 	} cpu;
 
 	struct Mem {

--- a/libgambatte/src/statesaver.cpp
+++ b/libgambatte/src/statesaver.cpp
@@ -223,6 +223,7 @@ SaverList::SaverList() {
 	{ static char const label[] = { h,             NUL }; ADD(cpu.h); }
 	{ static char const label[] = { l,             NUL }; ADD(cpu.l); }
 	{ static char const label[] = { s,k,i,p,       NUL }; ADD(cpu.skip); }
+	{ static char const label[] = { h,a,n,g,       NUL }; ADD(cpu.hang); }
 	{ static char const label[] = { h,a,l,t,       NUL }; ADD(mem.halted); }
 	{ static char const label[] = { v,r,a,m,       NUL }; ADDPTR(mem.vram); }
 	{ static char const label[] = { s,r,a,m,       NUL }; ADDPTR(mem.sram); }


### PR DESCRIPTION
When an invalid opcode is reached (including malformed `stop` instructions), the CPU will now hang, like an actual Game Boy would.

(Note that this doubles the cycles necessary to start a stop instruction, as the second byte of a stop instruction is now read; feel free to correct this if it's incorrect behaviour.)