### PR TITLE
Enable support for more than four SRAM banks

### DIFF
--- a/libgambatte/src/mem/pakinfo.cpp
+++ b/libgambatte/src/mem/pakinfo.cpp
@@ -20,9 +20,10 @@ unsigned numRambanksFromH14x(unsigned char h147, unsigned char h149) {
 	case 0x00: return isMbc2(h147) ? 1 : 0;
 	case 0x01:
 	case 0x02: return 1;
+	default: case 0x03: return 4;
+	case 0x04: return 16;
+	case 0x05: return 8;
 	}
-
-	return 4;
 }
 
 PakInfo::PakInfo()


### PR DESCRIPTION
More cases of the SRAM flag of the cartridge header are now considered, allowing 64KiB and 128KiB saves to be made (with 8 and 16 banks, respectively).

The extra space is taken advantage of by software such as LSDj.