### PR TITLE
Fixed MBC5 rom bank switching

### DIFF
--- a/libgambatte/src/mem/cartridge.cpp
+++ b/libgambatte/src/mem/cartridge.cpp
@@ -448,14 +448,12 @@ private:
 	unsigned char rambank_;
 	bool enableRam_;
 
-	static unsigned adjustedRombank(unsigned bank) { return bank ? bank : 1; }
-
 	void setRambank() const {
 		memptrs_.setRambank(enableRam_ ? MemPtrs::read_en | MemPtrs::write_en : 0,
 		                    rambank_ & (rambanks(memptrs_) - 1));
 	}
 
-	void setRombank() const { memptrs_.setRombank(adjustedRombank(rombank_) & (rombanks(memptrs_) - 1)); }
+	void setRombank() const { memptrs_.setRombank(rombank_ & (rombanks(memptrs_) - 1)); }
 };
 
 static bool hasRtc(unsigned headerByte0x147) {


### PR DESCRIPTION
This should make it possible to switch to ROM bank 0 on MBC5 cartridges, according to http://gbdev.gg8.se/wiki/articles/MBC5