### PR TITLE
Fix crash for ROMs with RTC (revert logic in MemPtrs::setRambank).

### DIFF
--- a/libgambatte/src/mem/memptrs.cpp
+++ b/libgambatte/src/mem/memptrs.cpp
@@ -128,15 +128,15 @@ void MemPtrs::setRambank(unsigned const flags, unsigned const rambank) {
 	unsigned char *srambankptr = 0;
 	if (!(flags & rtc_en)) {
 		srambankptr = rambankdata() != rambankdataend()
-			? rambankdata_ + rambank * rambank_size()
-			: wdisabledRam();
+			? rambankdata_ + rambank * rambank_size() - mm_sram_begin
+			: wdisabledRam() - mm_sram_begin;
 	}
 
-	rsrambankptr_ = (flags & read_en) && srambankptr != wdisabledRam()
-		? srambankptr - mm_sram_begin
+	rsrambankptr_ = (flags & read_en) && srambankptr != wdisabledRam() - mm_sram_begin
+		? srambankptr
 		: rdisabledRamw() - mm_sram_begin;
 	wsrambankptr_ = flags & write_en
-		? srambankptr - mm_sram_begin
+		? srambankptr
 		: wdisabledRam() - mm_sram_begin;
 	rmem_[0xB] = rmem_[0xA] = rsrambankptr_;
 	wmem_[0xB] = wmem_[0xA] = wsrambankptr_;


### PR DESCRIPTION
ROMs with MBC3 RTC currently crash when trying to read in RTC values on the latest versions of gambatte. The logic for setting rambank pointers was functionally changed in [this commit](https://github.com/sinamas/gambatte/commit/326db1999d85a5f4c4295aa0bf694d454883d9dd). 

This pull request reverts the offending lines, but keeps the refactored constant names. Perhaps there was a cleaner idea for the logic; the pull request is mainly to bring the issue to your attention.