### PR TITLE
Fix missing include in cartridge.cpp

### DIFF
--- a/libgambatte/src/mem/cartridge.cpp
+++ b/libgambatte/src/mem/cartridge.cpp
@@ -21,6 +21,7 @@
 #include "../savestate.h"
 #include "pakinfo_internal.h"
 
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 


### PR DESCRIPTION
Include 'algorithm' in cartridge.cpp. This header is required for 'std::max', which is used by cartridge.cpp in a couple places.

For some reason, the missing include went unnoticed with GCC, but it broke the build with Clang and MSVC.